### PR TITLE
fix: Use vector::empty for idiomatic emptiness check

### DIFF
--- a/Plugin/vtkOmniverseConnector/vtkOmniConnectActorNodeBase.cxx
+++ b/Plugin/vtkOmniverseConnector/vtkOmniConnectActorNodeBase.cxx
@@ -285,7 +285,7 @@ void vtkOmniConnectActorNodeBase::ConnectorBuild(bool prepass, vtkOmniConnectRen
 
       //In case we reopened an existing session, the scene to anim times have to be restored on the actor cache
       std::vector<double>& sceneToAnimTimes = Internals->ConnectActorCache->GetSceneToAnimationTimes();
-      if(sceneToAnimTimes.size() == 0 && !connector->GetSettings().CreateNewOmniSession)
+      if(sceneToAnimTimes.empty() && !connector->GetSettings().CreateNewOmniSession)
       {
         size_t numSceneToAnimTimes = connector->GetNumSceneToAnimTimes(actorId);
         if(numSceneToAnimTimes > 0)


### PR DESCRIPTION
This PR addresses the following issue in `Plugin/vtkOmniverseConnector/vtkOmniConnectActorNodeBase.cxx`: Use vector::empty for idiomatic emptiness check.

## Changes
- `Plugin/vtkOmniverseConnector/vtkOmniConnectActorNodeBase.cxx`: Use vector::empty for idiomatic emptiness check.

## Details
```diff
--- a/Plugin/vtkOmniverseConnector/vtkOmniConnectActorNodeBase.cxx
+++ b/Plugin/vtkOmniverseConnector/vtkOmniConnectActorNodeBase.cxx
@@ -1,2 +1,2 @@
-      if(sceneToAnimTimes.size() == 0 && !connector->GetSettings().CreateNewOmniSession)
-      {
+      if(sceneToAnimTimes.empty() && !connector->GetSettings().CreateNewOmniSession)
+      {
```

## Tests

> Let me know if you want tests added for this fix or not.